### PR TITLE
Fix current and parent directory paths for gems

### DIFF
--- a/gemfile.js
+++ b/gemfile.js
@@ -73,7 +73,7 @@ function interpret(string, extractMeta) {
 
       let data = {};
 
-      if (value.indexOf('/') > -1)  {
+      if (value.indexOf('/') > -1 || value.match(/^\.{1,2}$/)) {
         data.path = value;
       } else if (value.indexOf('(') > -1) {
         if (value[value.length - 1] === '!') {

--- a/test/Gemfile3.json
+++ b/test/Gemfile3.json
@@ -1,0 +1,33 @@
+{
+  "bundledWith": "2.2.19",
+  "rubyVersion": "2.7.3p183",
+  "platforms": {
+    "x86_64-linux": {}
+  },
+  "dependencies": {
+    "current-path-gem": {
+      "outsourced": true,
+      "version": "= 0.1.0"
+    },
+    "parent-path-gem": {
+      "outsourced": true,
+      "version": "= 0.1.0"
+    }
+  },
+  "specs": {
+    "current-path-gem": {
+      "version": "0.1.0",
+      "type": "PATH",
+      "remote": {
+        "path": "."
+      }
+    },
+    "parent-path-gem": {
+      "version": "0.1.0",
+      "type": "PATH",
+      "remote": {
+        "path": ".."
+      }
+    }
+  }
+}

--- a/test/Gemfile3.lock
+++ b/test/Gemfile3.lock
@@ -1,0 +1,26 @@
+PATH
+  remote: ..
+  specs:
+    parent-path-gem (0.1.0)
+
+PATH
+  remote: .
+  specs:
+    current-path-gem (0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  current-path-gem (= 0.1.0)!
+  parent-path-gem (= 0.1.0)!
+
+RUBY VERSION
+   ruby 2.7.3p183
+
+BUNDLED WITH
+   2.2.19

--- a/test/gemfile.test.js
+++ b/test/gemfile.test.js
@@ -52,6 +52,16 @@ describe('gemfile', function() {
             gemfile.interpret('test: some/path'),
             {test: {path: 'some/path'}}
           );
+
+          assert.deepEqual(
+            gemfile.interpret('test: .'),
+            {test: {path: '.'}}
+          );
+
+          assert.deepEqual(
+            gemfile.interpret('test: ..'),
+            {test: {path: '..'}}
+          );
         });
 
         it('versions', function() {

--- a/test/gemfile.test.js
+++ b/test/gemfile.test.js
@@ -166,7 +166,7 @@ describe('gemfile', function() {
       assert.property(output.specs.rspec, 'revision');
     });
 
-    ['Gemfile', 'Gemfile2'].forEach(function(filename) {
+    ['Gemfile', 'Gemfile2', 'Gemfile3'].forEach(function(filename) {
       it('returns exactly what we expect for ' + filename, function() {
         let file = fs.readFileSync('test/' + filename + '.lock', 'utf8');
         let expected = JSON.parse(


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Given you have the following `Gemfile`:

```
# frozen_string_literal: true

source "https://rubygems.org"

git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }

ruby "2.7.3"

gem "current-path-gem", "0.1.0", path: "."
gem "parent-path-gem", "0.1.0", path: ".."
```

This produces the following `Gemfile.lock`:

```
PATH
  remote: ..
  specs:
    parent-path-gem (0.1.0)

PATH
  remote: .
  specs:
    current-path-gem (0.1.0)

GEM
  remote: https://rubygems.org/
  specs:

PLATFORMS
  x86_64-linux

DEPENDENCIES
  current-path-gem (= 0.1.0)!
  parent-path-gem (= 0.1.0)!

RUBY VERSION
   ruby 2.7.3p183

BUNDLED WITH
   2.2.19
```

The `gemfile` package does not identify the paths for the current and parent path when the path definition does not have a `/` character in it.

### Notes for the reviewer

See the added Gemfile lock for reference what this is about.

### More information

N/A

### Screenshots

N/A